### PR TITLE
chore: releax internals stub buildtag to golang 1.21

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.16', '1.17', '1.18', '1.19', '1.20.0-rc.2']
+        go: ['1.16', '1.17', '1.18', '1.19', '1.20.0-rc.2', '1.21.0-rc.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/compat/stub_test.go
+++ b/compat/stub_test.go
@@ -2,9 +2,10 @@ package compat
 
 import (
 	"go/types"
-	"golang.org/x/tools/go/packages"
 	"strings"
 	"testing"
+
+	"golang.org/x/tools/go/packages"
 )
 
 func TestSignatureExpandFinalInlineFrame(t *testing.T) {

--- a/example/main.go
+++ b/example/main.go
@@ -3,13 +3,14 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/pyroscope-io/godeltaprof"
-	_ "github.com/pyroscope-io/godeltaprof/http/pprof"
 	"net/http"
 	_ "net/http/pprof"
 	"runtime"
 	"sync"
 	"time"
+
+	"github.com/pyroscope-io/godeltaprof"
+	_ "github.com/pyroscope-io/godeltaprof/http/pprof"
 )
 
 //go:noinline

--- a/internal/pprof/stub.go
+++ b/internal/pprof/stub.go
@@ -1,5 +1,5 @@
-//go:build go1.16 && !go1.21
-// +build go1.16,!go1.21
+//go:build go1.16 && !go1.22
+// +build go1.16,!go1.22
 
 package pprof
 


### PR DESCRIPTION
https://github.com/grafana/godeltaprof/issues/4