### PR TITLE
ci: update go deps

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,11 +12,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.16', '1.17', '1.18', '1.19', '1.20.0-rc.2', '1.21.0-rc.3']
+        go: ['1.16', '1.17', '1.18', '1.19', '1.20', '1.21']
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
       - name: Build example application


### PR DESCRIPTION
go 1.21 has been released for a while, updating the go dep matrix accordingly. Thanks!